### PR TITLE
Add processing_channel_id & marketplace properties

### DIFF
--- a/abc_spec/components/schemas/PaymentLinks/GetPaymentLinkResponse.yaml
+++ b/abc_spec/components/schemas/PaymentLinks/GetPaymentLinkResponse.yaml
@@ -116,13 +116,13 @@ properties:
           type: integer
           description: Minor units. Includes tax, excludes discounts.
           example: 200
-        metadata:
-          type: object
-          title: The Metadata Schema
-          description: Any additional information stored at the point of creation.
-          additionalProperties: true
-        return_url:
-          type: string
-          format: uri
-          description: The provided success page where your customer will be redirected to.
-          example: https://example.com/success
+  metadata:
+    type: object
+    title: The Metadata Schema
+    description: Any additional information stored at the point of creation.
+    additionalProperties: true
+  return_url:
+    type: string
+    format: uri
+    description: The provided success page where your customer will be redirected to.
+    example: https://example.com/success

--- a/nas_spec/components/schemas/HostedPayments/HostedPaymentsRequest.yaml
+++ b/nas_spec/components/schemas/HostedPayments/HostedPaymentsRequest.yaml
@@ -190,3 +190,10 @@ properties:
       Providing this field will automatically set `capture` to true.
     allOf:
       - $ref: '#/components/schemas/Timestamp'
+  processing_channel_id:
+    type: string
+    pattern: "^(pc)_(\\w{26})$"
+    description: The processing channel to be used for the payment
+    example: 'pc_q4dbxom5jbgudnjzjpz7j2z6uq'
+  marketplace:
+    $ref: '#/components/schemas/MarketplaceData'

--- a/nas_spec/components/schemas/PaymentLinks/GetPaymentLinkResponse.yaml
+++ b/nas_spec/components/schemas/PaymentLinks/GetPaymentLinkResponse.yaml
@@ -59,6 +59,13 @@ properties:
     description: The date and time when the Payment Link expires.
     format: date-time
     example: '2021-08-20T20:25:28+08:00'
+  processing_channel_id:
+    type: string
+    pattern: "^(pc)_(\\w{26})$"
+    description: The processing channel to be used for the payment
+    example: 'pc_q4dbxom5jbgudnjzjpz7j2z6uq'
+  marketplace:
+    $ref: '#/components/schemas/MarketplaceData'
   customer:
     type: object
     description: The customer's details.

--- a/nas_spec/components/schemas/PaymentLinks/GetPaymentLinkResponse.yaml
+++ b/nas_spec/components/schemas/PaymentLinks/GetPaymentLinkResponse.yaml
@@ -123,13 +123,13 @@ properties:
           type: integer
           description: Minor units. Includes tax, excludes discounts.
           example: 200
-        metadata:
-          type: object
-          title: The Metadata Schema
-          description: Any additional information stored at the point of creation.
-          additionalProperties: true
-        return_url:
-          type: string
-          format: uri
-          description: The provided success page where your customer will be redirected to.
-          example: https://example.com/success
+  metadata:
+    type: object
+    title: The Metadata Schema
+    description: Any additional information stored at the point of creation.
+    additionalProperties: true
+  return_url:
+    type: string
+    format: uri
+    description: The provided success page where your customer will be redirected to.
+    example: https://example.com/success

--- a/nas_spec/components/schemas/PaymentLinks/PaymentLinksRequest.yaml
+++ b/nas_spec/components/schemas/PaymentLinks/PaymentLinksRequest.yaml
@@ -181,3 +181,10 @@ properties:
       Providing this field will automatically set `capture` to true.
     allOf:
       - $ref: '#/components/schemas/Timestamp'
+  processing_channel_id:
+    type: string
+    pattern: "^(pc)_(\\w{26})$"
+    description: The processing channel to be used for the payment
+    example: 'pc_q4dbxom5jbgudnjzjpz7j2z6uq'
+  marketplace:
+    $ref: '#/components/schemas/MarketplaceData'


### PR DESCRIPTION
### Description of changes in PR

JIRA: [PI-1325], [PI-1326]

- Adds `processing_channel_id` and `marketplace` fields to the NAS spec for:
  - `HostedPaymentsRequest`
  - `PaymentLinksRequest`
  - `GetPaymentLinkResponse`
- Fix the structure of `metadata` and `return_url` properties in `GetPaymentLinkResponse`
  It seems these were previously incorrectly indented to be properties of `products` when they should be root-level properties of the response object.

### Technical Writer

[//]: # 'Tag your Technical Writer'
@chrisi-webster-cko


[PI-1325]: https://checkout.atlassian.net/browse/PI-1325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PI-1326]: https://checkout.atlassian.net/browse/PI-1326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ